### PR TITLE
fix(m6): Replace static DOM ids with useId in LoginPage/SignupPage (Issue #22)

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useId } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -21,6 +21,8 @@ type LoginForm = z.infer<typeof loginSchema>;
 const LoginPage = () => {
   const navigate = useNavigate();
   const [submitting, setSubmitting] = useState(false);
+  const emailId = useId();
+  const passwordId = useId();
 
   const {
     register,
@@ -58,9 +60,9 @@ const LoginPage = () => {
         <CardContent>
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
+              <Label htmlFor={emailId}>Email</Label>
               <Input
-                id="email"
+                id={emailId}
                 type="email"
                 placeholder="seu@email.com"
                 {...register("email")}
@@ -70,9 +72,9 @@ const LoginPage = () => {
               )}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password">Senha</Label>
+              <Label htmlFor={passwordId}>Senha</Label>
               <Input
-                id="password"
+                id={passwordId}
                 type="password"
                 placeholder="••••••"
                 {...register("password")}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useId } from "react";
 import { Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -27,6 +27,9 @@ type SignupForm = z.infer<typeof signupSchema>;
 const SignupPage = () => {
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
+  const emailId = useId();
+  const passwordId = useId();
+  const confirmPasswordId = useId();
 
   const {
     register,
@@ -83,18 +86,18 @@ const SignupPage = () => {
         <CardContent>
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input id="email" type="email" placeholder="seu@email.com" {...register("email")} />
+              <Label htmlFor={emailId}>Email</Label>
+              <Input id={emailId} type="email" placeholder="seu@email.com" {...register("email")} />
               {errors.email && <p className="text-xs text-destructive">{errors.email.message}</p>}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="password">Senha</Label>
-              <Input id="password" type="password" placeholder="••••••" {...register("password")} />
+              <Label htmlFor={passwordId}>Senha</Label>
+              <Input id={passwordId} type="password" placeholder="••••••" {...register("password")} />
               {errors.password && <p className="text-xs text-destructive">{errors.password.message}</p>}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="confirmPassword">Confirmar Senha</Label>
-              <Input id="confirmPassword" type="password" placeholder="••••••" {...register("confirmPassword")} />
+              <Label htmlFor={confirmPasswordId}>Confirmar Senha</Label>
+              <Input id={confirmPasswordId} type="password" placeholder="••••••" {...register("confirmPassword")} />
               {errors.confirmPassword && <p className="text-xs text-destructive">{errors.confirmPassword.message}</p>}
             </div>
             <Button type="submit" className="w-full" disabled={submitting}>


### PR DESCRIPTION
## Issue #22 — Replace static DOM IDs with useRef/useId (m6)

### Audit

- **LoginPage:** `id="email"`, `id="password"` — used only with `<Label htmlFor="...">` for accessibility. No `getElementById` or DOM manipulation.
- **SignupPage:** `id="email"`, `id="password"`, `id="confirmPassword"` — same.

### Change

Replaced **static ids** with **React `useId()`** so that:
- No static `id="..."` strings remain (m6).
- Label/input association is preserved (a11y): `htmlFor={emailId}` and `id={emailId}`.

`useRef` was not required because nothing referenced the inputs via DOM (only `register()` from react-hook-form).

### Files

- `src/pages/LoginPage.tsx` — `useId()` for email + password
- `src/pages/SignupPage.tsx` — `useId()` for email + password + confirmPassword

- [x] `npm run build` passes

Made with [Cursor](https://cursor.com)