### PR TITLE
fix(m1): Replace any types in non-UI code (Issue #18)

### DIFF
--- a/src/components/InteractionsFeed.tsx
+++ b/src/components/InteractionsFeed.tsx
@@ -23,8 +23,8 @@ interface Interaction {
   tone: string | null;
   theme: string | null;
   classified_at: string | null;
-  raw_payload: any;
-  attachments: any;
+  raw_payload: Record<string, unknown>;
+  attachments: unknown[];
 }
 
 interface Conversation {
@@ -87,10 +87,14 @@ function getAttachmentName(att: Attachment): string {
   }
 }
 
-function parseAttachments(raw: any): Attachment[] {
+function parseAttachments(raw: unknown): Attachment[] {
   if (!raw) return [];
-  if (Array.isArray(raw)) return raw.filter((a: any) => a?.url);
-  return [];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((a): a is Attachment => {
+    if (typeof a !== "object" || a === null) return false;
+    const o = a as Record<string, unknown>;
+    return typeof o.url === "string";
+  });
 }
 
 // ---------- Helpers ----------
@@ -168,7 +172,8 @@ function buildConversations(interactions: Interaction[]): Conversation[] {
 
     const worstTone = messages.reduce<"ok" | "atencao" | "alerta" | "critico">((worst, msg) => {
       const t = (msg.tone ?? "ok") as string;
-      return (TONE_RANK[t] ?? 0) > (TONE_RANK[worst] ?? 0) ? (t as any) : worst;
+      const tone = t as "ok" | "atencao" | "alerta" | "critico";
+      return (TONE_RANK[t] ?? 0) > (TONE_RANK[worst] ?? 0) ? tone : worst;
     }, "ok");
 
     const themeMsg = [...messages].reverse().find((m) => m.theme != null);

--- a/src/context/ClientContext.tsx
+++ b/src/context/ClientContext.tsx
@@ -5,6 +5,10 @@ import { useAuth } from "@/context/AuthContext";
 import { toast } from "sonner";
 
 // ── Types ──
+// job_status matches Database["public"]["Enums"]["job_status"] (types.ts); local alias to avoid editing generated file
+type JobStatus = "pending" | "running" | "completed" | "failed" | "cancelled";
+
+const ACTIVE_JOB_STATUSES: JobStatus[] = ["pending", "running"];
 
 interface Client {
   id: string;
@@ -117,7 +121,7 @@ export function ClientProvider({ children }: { children: ReactNode }) {
   const [jobs, setJobs] = useState<SyncJobRecord[]>([]);
   const [startedAt, setStartedAt] = useState<number | null>(null);
   const fallbackRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const channelRef = useRef<any>(null);
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
 
   const { data: clients = [], isLoading } = useQuery<Client[]>({
     queryKey: ["clients", user?.id],
@@ -146,21 +150,22 @@ export function ClientProvider({ children }: { children: ReactNode }) {
       const { data } = await supabase
         .from('sync_jobs')
         .select('*')
-        .in('status', ['pending', 'running'] as any)
+        .in('status', ACTIVE_JOB_STATUSES)
         .order('created_at', { ascending: true });
-      if (data && data.length > 0) {
-        const ids = data.map((j: any) => j.id);
+      const rows = (data ?? []) as SyncJobRecord[];
+      if (rows.length > 0) {
+        const ids = rows.map((j) => j.id);
         setActiveJobIds(prev => {
           const merged = new Set([...prev, ...ids]);
           return Array.from(merged);
         });
         setJobs(prev => {
           const existingIds = new Set(prev.map(j => j.id));
-          const newJobs = (data as SyncJobRecord[]).filter(j => !existingIds.has(j.id));
+          const newJobs = rows.filter(j => !existingIds.has(j.id));
           return newJobs.length > 0 ? [...prev, ...newJobs] : prev;
         });
         if (!startedAt) {
-          const earliest = data.find((j: any) => j.started_at);
+          const earliest = rows.find((j) => j.started_at);
           setStartedAt(earliest?.started_at ? new Date(earliest.started_at).getTime() : Date.now());
         }
       }
@@ -260,10 +265,10 @@ export function ClientProvider({ children }: { children: ReactNode }) {
       const hasCancelled = jobs.some(j => j.status === 'cancelled');
       const totalContacts = jobs
         .filter(j => j.type === 'sync_contacts')
-        .reduce((s, j) => s + ((j.progress as any)?.contacts_processed || 0), 0);
+        .reduce((s, j) => s + (Number((j.progress as Record<string, unknown> | null)?.contacts_processed) || 0), 0);
       const totalMessages = jobs
         .filter(j => j.type === 'ingest_historical')
-        .reduce((s, j) => s + ((j.progress as any)?.messages_inserted || 0), 0);
+        .reduce((s, j) => s + (Number((j.progress as Record<string, unknown> | null)?.messages_inserted) || 0), 0);
 
       if (hasCancelled) {
         toast.info("Sincronização cancelada pelo usuário.");
@@ -334,9 +339,9 @@ export function ClientProvider({ children }: { children: ReactNode }) {
     for (const jobId of activeJobIds) {
       await supabase
         .from('sync_jobs')
-        .update({ status: 'cancelled' as any, completed_at: new Date().toISOString() })
+        .update({ status: 'cancelled' as JobStatus, completed_at: new Date().toISOString() })
         .eq('id', jobId)
-        .in('status', ['pending', 'running'] as any);
+        .in('status', ACTIVE_JOB_STATUSES);
     }
   }, [activeJobIds]);
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -96,7 +96,7 @@ function AutoSyncCard() {
     queryKey: ["app_settings", "auto_sync_enabled"],
     staleTime: 60 * 1000,
     queryFn: async () => {
-      const { data, error } = await (supabase as any)
+      const { data, error } = await supabase
         .from("app_settings")
         .select("value")
         .eq("key", "auto_sync_enabled")
@@ -109,7 +109,7 @@ function AutoSyncCard() {
 
   const toggleMutation = useMutation({
     mutationFn: async (enabled: boolean) => {
-      const { error } = await (supabase as any)
+      const { error } = await supabase
         .from("app_settings")
         .update({ value: enabled, updated_at: new Date().toISOString() })
         .eq("key", "auto_sync_enabled");
@@ -362,7 +362,12 @@ const SettingsPage = () => {
   const handleRetryJob = useCallback(async (jobId: string) => {
     const { error } = await supabase
       .from('sync_jobs')
-      .update({ status: 'pending' as any, retry_count: 0, completed_at: null, heartbeat_at: null } as any)
+      .update({
+        status: 'pending',
+        retry_count: 0,
+        completed_at: null,
+        heartbeat_at: null,
+      })
       .eq('id', jobId);
     if (error) {
       toast.error("Erro ao retentar: " + error.message);
@@ -386,7 +391,7 @@ const SettingsPage = () => {
     }
     setApplyingRule(true);
     try {
-      const { data, error } = await (supabase.rpc as any)("deactivate_stale_clients", { _days: inactiveDays });
+      const { data, error } = await supabase.rpc("deactivate_stale_clients", { _days: inactiveDays });
       if (error) throw error;
       const count = typeof data === "number" ? data : 0;
       toast.success(`${count} cliente(s) inativado(s).`);


### PR DESCRIPTION
## Issue #18 — Replace any types with proper types (m1)

### InteractionsFeed
- `raw_payload: any` → `Record<string, unknown>`
- `attachments: any` → `unknown[]`
- `parseAttachments(raw: any)` → `raw: unknown` + type guard returning `Attachment[]`
- Tone cast `(t as any)` → `(t as "ok" | "atencao" | "alerta" | "critico")`

### ClientContext
- Local type `JobStatus` and `ACTIVE_JOB_STATUSES` for `.in('status', ...)` and `.update({ status: 'cancelled' })` (no `as any`)
- `data` from select cast to `SyncJobRecord[]`; `map((j) => j.id)`, `find((j) => j.started_at)` typed
- `j.progress` as `Record<string, unknown> | null` for `contacts_processed` / `messages_inserted`
- `channelRef` typed as `ReturnType<typeof supabase.channel>`

### SettingsPage
- Removed `(supabase as any)` for `app_settings` select/update (typed client)
- Removed `(supabase.rpc as any)` for `deactivate_stale_clients`
- `sync_jobs` update with plain object (no `as any`)

- [x] `src/integrations/supabase/*` not edited
- [x] `npm run build` passes

Made with [Cursor](https://cursor.com)