### PR TITLE
fix(m9): Replace useState loading with useMutation (Issue #20)

### DIFF
--- a/src/pages/ClientDetailPage.tsx
+++ b/src/pages/ClientDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -168,8 +168,6 @@ const ClientDetailPage = () => {
   const queryClient = useQueryClient();
 
   const [scopeText, setScopeText] = useState<string | null>(null);
-  const [savingScope, setSavingScope] = useState(false);
-  const [deactivating, setDeactivating] = useState(false);
 
   const thirtyDaysAgo = useMemo(
     () => new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(), []
@@ -346,42 +344,40 @@ const ClientDetailPage = () => {
 
   // ── Actions ──
 
-  const handleSaveScope = async () => {
-    if (!client) return;
-    setSavingScope(true);
-    try {
-      const existing = (client.metadata ?? {}) as Record<string, unknown>;
+  const saveScopeMutation = useMutation({
+    mutationFn: async (payload: { client: ClientDetail; scopeText: string | null }) => {
+      const existing = (payload.client.metadata ?? {}) as Record<string, unknown>;
       const { error } = await supabase
         .from("clients")
-        .update({ metadata: { ...existing, scope: scopeText } })
-        .eq("id", client.id);
+        .update({ metadata: { ...existing, scope: payload.scopeText } })
+        .eq("id", payload.client.id);
       if (error) throw error;
+    },
+    onSuccess: () => {
       toast.success("Escopo salvo!");
       queryClient.invalidateQueries({ queryKey: ["client_detail", user?.id, slug] });
-    } catch (err) {
+    },
+    onError: (err) => {
       toast.error("Erro ao salvar: " + (err instanceof Error ? err.message : "Erro"));
-    } finally {
-      setSavingScope(false);
-    }
-  };
+    },
+  });
 
-  const handleDeactivate = async () => {
-    if (!client) return;
-    setDeactivating(true);
-    try {
+  const deactivateMutation = useMutation({
+    mutationFn: async (clientToDeactivate: ClientDetail) => {
       const { error } = await supabase
         .from("clients")
         .update({ active: false })
-        .eq("id", client.id);
+        .eq("id", clientToDeactivate.id);
       if (error) throw error;
+    },
+    onSuccess: () => {
       toast.success("Cliente desativado");
       navigate("/clients");
-    } catch (err) {
+    },
+    onError: (err) => {
       toast.error("Erro: " + (err instanceof Error ? err.message : "Erro"));
-    } finally {
-      setDeactivating(false);
-    }
-  };
+    },
+  });
 
   const handleToggleRule = async (ruleId: string, active: boolean) => {
     const { error } = await supabase
@@ -750,8 +746,12 @@ const ClientDetailPage = () => {
                 value={scopeText ?? ""}
                 onChange={(e) => setScopeText(e.target.value)}
               />
-              <Button size="sm" onClick={handleSaveScope} disabled={savingScope}>
-                {savingScope && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
+              <Button
+                size="sm"
+                onClick={() => client && saveScopeMutation.mutate({ client, scopeText })}
+                disabled={saveScopeMutation.isPending}
+              >
+                {saveScopeMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
                 Salvar Escopo
               </Button>
             </CardContent>
@@ -885,11 +885,11 @@ const ClientDetailPage = () => {
                   <AlertDialogFooter>
                     <AlertDialogCancel>Cancelar</AlertDialogCancel>
                     <AlertDialogAction
-                      onClick={handleDeactivate}
-                      disabled={deactivating}
+                      onClick={() => client && deactivateMutation.mutate(client)}
+                      disabled={deactivateMutation.isPending}
                       className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                     >
-                      {deactivating && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
+                      {deactivateMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-1" />}
                       Confirmar desativação
                     </AlertDialogAction>
                   </AlertDialogFooter>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -178,7 +178,6 @@ const SettingsPage = () => {
   const [syncError, setSyncError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<"active" | "inactive" | "all">("active");
   const [inactiveDays, setInactiveDays] = useState(90);
-  const [applyingRule, setApplyingRule] = useState(false);
   const queryClient = useQueryClient();
 
   // ── Queries ──
@@ -382,28 +381,24 @@ const SettingsPage = () => {
     startSync({ syncContacts: false, syncHistory: true });
   }, [startSync]);
 
-  // ── Inactivation rule handler ──
+  // ── Inactivation rule mutation ──
 
-  const handleApplyInactivationRule = useCallback(async () => {
-    if (inactiveDays < 1) {
-      toast.error("O número de dias deve ser pelo menos 1.");
-      return;
-    }
-    setApplyingRule(true);
-    try {
-      const { data, error } = await supabase.rpc("deactivate_stale_clients", { _days: inactiveDays });
+  const applyInactivationRuleMutation = useMutation({
+    mutationFn: async (days: number) => {
+      if (days < 1) throw new Error("O número de dias deve ser pelo menos 1.");
+      const { data, error } = await supabase.rpc("deactivate_stale_clients", { _days: days });
       if (error) throw error;
-      const count = typeof data === "number" ? data : 0;
+      return typeof data === "number" ? data : 0;
+    },
+    onSuccess: (count) => {
       toast.success(`${count} cliente(s) inativado(s).`);
       queryClient.invalidateQueries({ queryKey: ["sync_clients"] });
       queryClient.invalidateQueries({ queryKey: ["clients"] });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Erro desconhecido";
-      toast.error("Erro ao aplicar regra: " + msg);
-    } finally {
-      setApplyingRule(false);
-    }
-  }, [inactiveDays, queryClient]);
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Erro desconhecido");
+    },
+  });
 
   // ── Integration cards config ──
 
@@ -576,11 +571,11 @@ const SettingsPage = () => {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={handleApplyInactivationRule}
-                disabled={applyingRule}
+                onClick={() => applyInactivationRuleMutation.mutate(inactiveDays)}
+                disabled={applyInactivationRuleMutation.isPending}
                 className="ml-auto"
               >
-                {applyingRule ? (
+                {applyInactivationRuleMutation.isPending ? (
                   <><Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> Aplicando...</>
                 ) : (
                   "Aplicar regra agora"


### PR DESCRIPTION
## Issue #20 — Replace useState manual loading with useMutation (m9)

### ClientDetailPage
1. **saveScope** — `saveScopeMutation` with `mutationFn` doing metadata merge + Supabase update; `onSuccess`: toast + `invalidateQueries({ queryKey: ['client_detail', user?.id, slug] })`; `onError`: toast. Button `disabled={saveScopeMutation.isPending}`.
2. **deactivate** — `deactivateMutation` with `mutationFn` updating `active: false`; `onSuccess`: toast + `navigate('/clients')`. AlertDialogAction `disabled={deactivateMutation.isPending}`.

### SettingsPage
3. **apply inactivation rule** — `applyInactivationRuleMutation` with `mutationFn` calling `supabase.rpc('deactivate_stale_clients', { _days })`; `onSuccess`: toast + invalidateQueries; `onError`: toast. Button `disabled={applyInactivationRuleMutation.isPending}`.

- Removed `savingScope`, `deactivating`, `applyingRule` useState.
- Same business logic; only state pattern changed (m9).

- [x] `npm run build` passes

Made with [Cursor](https://cursor.com)