### PR TITLE
fix: error states in ClientsPage and ClientDetailPage

### DIFF
--- a/src/pages/ClientDetailPage.tsx
+++ b/src/pages/ClientDetailPage.tsx
@@ -21,7 +21,8 @@ import {
 import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ChevronRight, Pencil, MoreHorizontal, Loader2, Upload } from "lucide-react";
+import { ChevronRight, Pencil, MoreHorizontal, Loader2, Upload, AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { InteractionsFeed } from "@/components/InteractionsFeed";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
@@ -179,7 +180,7 @@ const ClientDetailPage = () => {
 
   // ── Queries ──
 
-  const { data: client, isLoading: loadingClient } = useQuery<ClientDetail | null>({
+  const { data: client, isLoading: loadingClient, isError: clientError, refetch: refetchClient } = useQuery<ClientDetail | null>({
     queryKey: ["client_detail", user?.id, slug],
     enabled: !!slug && !!user?.id,
     staleTime: 5 * 60 * 1000,
@@ -417,6 +418,26 @@ const ClientDetailPage = () => {
         <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
           {[1, 2, 3, 4, 5, 6].map((i) => <Skeleton key={i} className="h-24 rounded-xl" />)}
         </div>
+      </div>
+    );
+  }
+
+  if (clientError) {
+    return (
+      <div className="space-y-4 p-6">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Erro ao carregar cliente</AlertTitle>
+          <AlertDescription>
+            Não foi possível carregar os dados. Tente novamente.
+            <Button variant="outline" size="sm" className="mt-2" onClick={() => refetchClient()}>
+              Tentar novamente
+            </Button>
+          </AlertDescription>
+        </Alert>
+        <Button variant="outline" onClick={() => navigate("/clients")}>
+          Voltar para Clientes
+        </Button>
       </div>
     );
   }

--- a/src/pages/ClientsPage.tsx
+++ b/src/pages/ClientsPage.tsx
@@ -11,7 +11,8 @@ import {
 import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { MoreHorizontal, Search, ArrowUp, ArrowDown, ArrowUpDown } from "lucide-react";
+import { MoreHorizontal, Search, ArrowUp, ArrowDown, ArrowUpDown, AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { useAuth } from "@/context/AuthContext";
@@ -128,7 +129,7 @@ const ClientsPage = () => {
     }
   }, [sortKey]);
 
-  const { data: clientsData, isLoading: loadingClients } = useQuery<{ list: ClientRow[]; totalCount: number }>({
+  const { data: clientsData, isLoading: loadingClients, isError: clientsError, refetch: refetchClients } = useQuery<{ list: ClientRow[]; totalCount: number }>({
     queryKey: ["clients_list", user?.id, page],
     enabled: !!user?.id,
     staleTime: 5 * 60 * 1000,
@@ -224,9 +225,22 @@ const ClientsPage = () => {
         </div>
       </div>
 
+      {clientsError && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Erro ao carregar clientes</AlertTitle>
+          <AlertDescription>
+            Não foi possível carregar a lista. Tente novamente.
+            <Button variant="outline" size="sm" className="mt-2" onClick={() => refetchClients()}>
+              Tentar novamente
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* Table */}
       <div className="rounded-xl border border-border bg-card">
-        {loadingClients ? (
+        {!clientsError && loadingClients ? (
           <div className="p-6 space-y-4">
             {[1, 2, 3].map((i) => (
               <div key={i} className="flex items-center gap-4">
@@ -239,7 +253,7 @@ const ClientsPage = () => {
               </div>
             ))}
           </div>
-        ) : clientsWithStats.length === 0 ? (
+        ) : !clientsError && clientsWithStats.length === 0 ? (
           <div className="py-20 text-center text-muted-foreground text-sm">
             Nenhum cliente ativo. Adicione um cliente para começar.
           </div>
@@ -337,7 +351,7 @@ const ClientsPage = () => {
             </TableBody>
           </Table>
         )}
-        {!loadingClients && clientsWithStats.length > 0 && totalCount > PAGE_SIZE && (
+        {!clientsError && !loadingClients && clientsWithStats.length > 0 && totalCount > PAGE_SIZE && (
           <div className="flex items-center justify-between px-4 py-3 border-t border-border">
             <span className="text-sm text-muted-foreground">
               Página {page + 1} de {Math.ceil(totalCount / PAGE_SIZE) || 1}


### PR DESCRIPTION
## Summary
- ClientsPage: show error state with retry when clients query fails (Alert destructive + refetch).
- ClientDetailPage: show error state with retry when client query fails; "Cliente não encontrado" only when `!client && !isError`.
- Aligns with m2 (error handling) and avoids silent failures.

## CTO Checklist
- m1: No `any` added.
- m2: Error states prevent route crash; user can retry.
- m3: No toast changes.
- m4/m5: Existing query usage unchanged.
- m8: Supabase errors surfaced via `isError` + refetch.
- m10: refetch() used in retry button.
- m11: No unused imports.

## Test plan
- ClientsPage: force network error or invalid RLS → see error Alert and "Tentar novamente"; click retry.
- ClientDetailPage: open valid client → OK; open invalid ID → "Cliente não encontrado"; force query error → error Alert + retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)