### PR TITLE
fix(m9): replace manual submitting state with useMutation in auth pages

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,9 @@
-import { useState, useId } from "react";
+import { useId } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import { useMutation } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -20,7 +21,6 @@ type LoginForm = z.infer<typeof loginSchema>;
 
 const LoginPage = () => {
   const navigate = useNavigate();
-  const [submitting, setSubmitting] = useState(false);
   const emailId = useId();
   const passwordId = useId();
 
@@ -30,22 +30,19 @@ const LoginPage = () => {
     formState: { errors },
   } = useForm<LoginForm>({ resolver: zodResolver(loginSchema) });
 
-  const onSubmit = async (values: LoginForm) => {
-    setSubmitting(true);
-    try {
+  const loginMutation = useMutation({
+    mutationFn: async (values: LoginForm) => {
       const { error } = await supabase.auth.signInWithPassword({
         email: values.email,
         password: values.password,
       });
       if (error) throw error;
-      navigate("/");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Erro ao fazer login";
-      toast.error(msg);
-    } finally {
-      setSubmitting(false);
-    }
-  };
+    },
+    onSuccess: () => navigate("/"),
+    onError: (err) => toast.error(err instanceof Error ? err.message : "Erro ao fazer login"),
+  });
+
+  const onSubmit = (values: LoginForm) => loginMutation.mutate(values);
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-background px-4">
@@ -83,8 +80,8 @@ const LoginPage = () => {
                 <p className="text-xs text-destructive">{errors.password.message}</p>
               )}
             </div>
-            <Button type="submit" className="w-full" disabled={submitting}>
-              {submitting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+            <Button type="submit" className="w-full" disabled={loginMutation.isPending}>
+              {loginMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
               Entrar
             </Button>
           </form>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import { useMutation } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -25,7 +26,6 @@ const signupSchema = z
 type SignupForm = z.infer<typeof signupSchema>;
 
 const SignupPage = () => {
-  const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const emailId = useId();
   const passwordId = useId();
@@ -37,22 +37,19 @@ const SignupPage = () => {
     formState: { errors },
   } = useForm<SignupForm>({ resolver: zodResolver(signupSchema) });
 
-  const onSubmit = async (values: SignupForm) => {
-    setSubmitting(true);
-    try {
+  const signupMutation = useMutation({
+    mutationFn: async (values: SignupForm) => {
       const { error } = await supabase.auth.signUp({
         email: values.email,
         password: values.password,
       });
       if (error) throw error;
-      setSuccess(true);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Erro ao criar conta";
-      toast.error(msg);
-    } finally {
-      setSubmitting(false);
-    }
-  };
+    },
+    onSuccess: () => setSuccess(true),
+    onError: (err) => toast.error(err instanceof Error ? err.message : "Erro ao criar conta"),
+  });
+
+  const onSubmit = (values: SignupForm) => signupMutation.mutate(values);
 
   if (success) {
     return (
@@ -100,8 +97,8 @@ const SignupPage = () => {
               <Input id={confirmPasswordId} type="password" placeholder="••••••" {...register("confirmPassword")} />
               {errors.confirmPassword && <p className="text-xs text-destructive">{errors.confirmPassword.message}</p>}
             </div>
-            <Button type="submit" className="w-full" disabled={submitting}>
-              {submitting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+            <Button type="submit" className="w-full" disabled={signupMutation.isPending}>
+              {signupMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
               Criar Conta
             </Button>
           </form>


### PR DESCRIPTION
## Summary
- LoginPage and SignupPage: remove manual `useState(submitting)`; use `useMutation` for submit (mutationFn, onSuccess, onError).
- Button loading state from `isPending`; errors shown via toast (sonner).
- Aligns with CTO checklist m9 (useMutation for writes).

## CTO Checklist
- m1: No `any` added.
- m3: Toast (sonner) for mutation errors.
- m9: useMutation for auth submit; no manual submitting state.
- m11: No unused imports.

## Test plan
- Login: submit valid credentials → success; invalid → error toast; button shows loading while pending.
- Signup: submit valid form → success; duplicate/invalid → error toast; button shows loading while pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)