### PR TITLE
fix: honest empty state for Audits page

### DIFF
--- a/src/pages/Audits.tsx
+++ b/src/pages/Audits.tsx
@@ -1,34 +1,25 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Plus, ShieldAlert } from "lucide-react";
+import { ShieldAlert } from "lucide-react";
 
 const Audits = () => {
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Auditorias</h1>
-          <p className="text-muted-foreground">
-            Configure alertas automáticos baseados nos seus indicadores
-          </p>
-        </div>
-        <Button>
-          <Plus className="h-4 w-4 mr-2" /> Nova Auditoria
-        </Button>
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Auditorias</h1>
+        <p className="text-muted-foreground">
+          Alertas automáticos baseados nos seus indicadores (Fase 6)
+        </p>
       </div>
 
-      <Card className="border-0 shadow-sm">
+      <Card className="border border-border">
         <CardContent className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-accent mb-4">
-            <ShieldAlert className="h-8 w-8 text-accent-foreground" />
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-muted mb-4">
+            <ShieldAlert className="h-8 w-8 text-muted-foreground" />
           </div>
-          <h3 className="text-lg font-semibold">Nenhuma auditoria configurada</h3>
+          <h3 className="text-lg font-semibold text-foreground">Em desenvolvimento</h3>
           <p className="text-muted-foreground mt-1 max-w-md">
-            Crie regras de alerta para ser notificado via WhatsApp, Email ou Slack quando seus indicadores atingirem condições específicas.
+            A gestão de auditorias e alertas será disponibilizada em uma próxima fase do CX Hub.
           </p>
-          <Button className="mt-4" variant="outline">
-            <Plus className="h-4 w-4 mr-2" /> Criar primeira auditoria
-          </Button>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- Replace misleading "Nova Auditoria" / "Criar primeira auditoria" with honest copy: "Em desenvolvimento" and "Fase 6".
- Remove action buttons that suggested audits are available; avoids confusion until feature is ready.

## CTO Checklist
- m1: No `any` added.
- m2: No new error paths; static content.
- m11: No unused imports.

## Test plan
- Open /audits → see "Em desenvolvimento" and "Fase 6"; no "Nova Auditoria" or "Criar primeira auditoria" buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)