### PR TITLE
fix: use React Router Link in NotFound page

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -13,9 +13,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="mb-4 text-4xl font-bold">404</h1>
         <p className="mb-4 text-xl text-muted-foreground">Página não encontrada</p>
-        <a href="/" className="text-primary underline hover:text-primary/90">
+        <Link to="/" className="text-primary underline hover:text-primary/90">
           Voltar para o início
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace `<a href="/">` with `<Link to="/">` in NotFound so navigation is in-app (no full reload).
- Aligns with SPA behaviour and avoids unnecessary full page load.

## CTO Checklist
- m1: No `any` added.
- m11: Link imported from react-router-dom; no unused imports.

## Test plan
- Navigate to unknown route → NotFound; click link to home → app navigates without full reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)