### PR TITLE
fix: dark mode tone/status colors, shimmer skeletons, layout padding

### DIFF
--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -53,7 +53,7 @@ export function DashboardLayout() {
             <div className="flex-1" />
           </header>
           <SyncProgressBar />
-          <main className="flex-1 p-6 overflow-auto">
+          <main className="flex-1 p-4 md:p-6 overflow-auto">
             <Outlet />
           </main>
         </div>

--- a/src/pages/ClientDetailPage.tsx
+++ b/src/pages/ClientDetailPage.tsx
@@ -106,10 +106,10 @@ interface AuditRule {
 // ── Helpers ──
 
 const TONE_CONFIG: Record<string, { label: string; className: string }> = {
-  ok: { label: "✓ Ok", className: "bg-green-100 text-green-700" },
-  atencao: { label: "⚠ Atenção", className: "bg-yellow-100 text-yellow-700" },
-  alerta: { label: "🔶 Alerta", className: "bg-orange-100 text-orange-700" },
-  critico: { label: "🔴 Crítico", className: "bg-red-100 text-red-700" },
+  ok: { label: "✓ Ok", className: "bg-emerald-50 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400" },
+  atencao: { label: "⚠ Atenção", className: "bg-yellow-50 text-yellow-600 dark:bg-yellow-950 dark:text-yellow-400" },
+  alerta: { label: "🔶 Alerta", className: "bg-orange-50 text-orange-600 dark:bg-orange-950 dark:text-orange-400" },
+  critico: { label: "🔴 Crítico", className: "bg-red-50 text-red-600 dark:bg-red-950 dark:text-red-400" },
 };
 
 const CHANNEL_ICONS: Record<string, string> = {
@@ -413,10 +413,10 @@ const ClientDetailPage = () => {
   if (loadingClient) {
     return (
       <div className="space-y-6 p-6">
-        <Skeleton className="h-8 w-64" />
-        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-8 w-64 animate-shimmer" />
+        <Skeleton className="h-4 w-40 animate-shimmer" />
         <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-          {[1, 2, 3, 4, 5, 6].map((i) => <Skeleton key={i} className="h-24 rounded-xl" />)}
+          {[1, 2, 3, 4, 5, 6].map((i) => <Skeleton key={i} className="h-24 rounded-xl animate-shimmer" />)}
         </div>
       </div>
     );
@@ -654,8 +654,8 @@ const ClientDetailPage = () => {
 
         {/* ── TAB 2: Participantes ── */}
         <TabsContent value="participants" className="space-y-6">
-          <ParticipantSection title="Time do cliente" participants={clientTeam} badgeColor="bg-orange-100 text-orange-700" />
-          <ParticipantSection title="Time uMode" participants={umodeTeam} badgeColor="bg-blue-100 text-blue-700" />
+          <ParticipantSection title="Time do cliente" participants={clientTeam} badgeColor="bg-orange-50 text-orange-600 dark:bg-orange-950 dark:text-orange-400" />
+          <ParticipantSection title="Time uMode" participants={umodeTeam} badgeColor="bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-400" />
           {participantsTotalCount > PAGE_SIZE && (
             <div className="flex items-center justify-between mt-4">
               <span className="text-sm text-muted-foreground">
@@ -703,7 +703,7 @@ const ClientDetailPage = () => {
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <Badge className="bg-green-100 text-green-700 border-0 text-xs">Ativo</Badge>
+                    <Badge className="bg-emerald-50 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400 border-0 text-xs">Ativo</Badge>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button variant="ghost" size="icon" className="h-8 w-8">

--- a/src/pages/ClientsPage.tsx
+++ b/src/pages/ClientsPage.tsx
@@ -59,10 +59,10 @@ const CHANNEL_ICONS: Record<string, string> = {
 };
 
 const TONE_CONFIG: Record<string, { label: string; className: string }> = {
-  ok: { label: "✓ Ok", className: "bg-green-100 text-green-700" },
-  atencao: { label: "⚠ Atenção", className: "bg-yellow-100 text-yellow-700" },
-  alerta: { label: "🔶 Alerta", className: "bg-orange-100 text-orange-700" },
-  critico: { label: "🔴 Crítico", className: "bg-red-100 text-red-700" },
+  ok: { label: "✓ Ok", className: "bg-emerald-50 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400" },
+  atencao: { label: "⚠ Atenção", className: "bg-yellow-50 text-yellow-600 dark:bg-yellow-950 dark:text-yellow-400" },
+  alerta: { label: "🔶 Alerta", className: "bg-orange-50 text-orange-600 dark:bg-orange-950 dark:text-orange-400" },
+  critico: { label: "🔴 Crítico", className: "bg-red-50 text-red-600 dark:bg-red-950 dark:text-red-400" },
 };
 
 function formatLastContact(dateStr: string | null): string {
@@ -244,12 +244,12 @@ const ClientsPage = () => {
           <div className="p-6 space-y-4">
             {[1, 2, 3].map((i) => (
               <div key={i} className="flex items-center gap-4">
-                <Skeleton className="h-5 w-40" />
-                <Skeleton className="h-5 w-20" />
-                <Skeleton className="h-5 w-16" />
-                <Skeleton className="h-5 w-20" />
-                <Skeleton className="h-2 w-16" />
-                <Skeleton className="h-5 w-28" />
+                <Skeleton className="h-5 w-40 animate-shimmer" />
+                <Skeleton className="h-5 w-20 animate-shimmer" />
+                <Skeleton className="h-5 w-16 animate-shimmer" />
+                <Skeleton className="h-5 w-20 animate-shimmer" />
+                <Skeleton className="h-2 w-16 animate-shimmer" />
+                <Skeleton className="h-5 w-28 animate-shimmer" />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- TONE_CONFIG in ClientsPage and ClientDetailPage: light/dark pairs per Design System 1.1 (emerald/yellow/orange/red with `*-50/*-600` light, `dark:*-950/dark:*-400` dark).
- Participant and status badges (Time do cliente, Time uMode, Ativo in Canais): dark variants added; progress bar colors (`bg-*-500`) unchanged.
- All Skeletons in ClientsPage (18) and ClientDetailPage (9) use `animate-shimmer` (registered in tailwind.config.ts).
- DashboardLayout main: `p-6` → `p-4 md:p-6` for responsive padding. SettingsPage not touched (PR-F/#43).

## CTO Checklist
- m1: No `any` added.
- m11: No new imports; zero unused imports.

## Test plan
- Light mode: ClientsPage and ClientDetailPage — tone badges, participant badges, "Ativo" badge readable; loading skeletons show shimmer.
- Dark mode: toggle dark theme — same elements use dark variants (emerald-950, yellow-950, orange-950, red-950, blue-950); no regression.
- Mobile: narrow viewport — main content has `p-4`; `md+` has `p-6`.
- SettingsPage: unchanged; jobStatusBadge dark mode remains from PR-F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)