### PR TITLE
fix: accessibility aria-labels, focus-visible, active:scale

### DIFF
--- a/src/pages/ClientDetailPage.tsx
+++ b/src/pages/ClientDetailPage.tsx
@@ -706,7 +706,7 @@ const ClientDetailPage = () => {
                     <Badge className="bg-emerald-50 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400 border-0 text-xs">Ativo</Badge>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <Button variant="ghost" size="icon" className="h-8 w-8 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2" aria-label="Menu do canal">
                           <MoreHorizontal className="h-4 w-4" />
                         </Button>
                       </DropdownMenuTrigger>

--- a/src/pages/ClientsPage.tsx
+++ b/src/pages/ClientsPage.tsx
@@ -99,9 +99,12 @@ function SortButton({ label, col, current, dir, onClick, className = "" }: {
 }) {
   const active = current === col;
   const Icon = active ? (dir === "asc" ? ArrowUp : ArrowDown) : ArrowUpDown;
+  const sortDesc = active ? (dir === "asc" ? " (ascendente)" : " (descendente)") : "";
   return (
     <button
-      className={`inline-flex items-center gap-1 hover:text-foreground transition-colors ${className}`}
+      type="button"
+      aria-label={`Ordenar por ${label}${sortDesc}`}
+      className={`inline-flex items-center gap-1 hover:text-foreground transition-colors transition-transform active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded ${className}`}
       onClick={(e) => { e.stopPropagation(); onClick(col); }}
     >
       {label}
@@ -286,8 +289,16 @@ const ClientsPage = () => {
                 return (
                   <TableRow
                     key={client.id}
-                    className="cursor-pointer hover:bg-muted/30"
+                    role="button"
+                    tabIndex={0}
+                    className="cursor-pointer hover:bg-muted/30 transition-transform active:scale-[0.995] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
                     onClick={() => navigate(`/clients/${client.slug}`)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        navigate(`/clients/${client.slug}`);
+                      }
+                    }}
                   >
                     <TableCell>
                       <div>
@@ -334,7 +345,7 @@ const ClientsPage = () => {
                     <TableCell>
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                          <Button variant="ghost" size="icon" className="h-8 w-8">
+                          <Button variant="ghost" size="icon" className="h-8 w-8 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2" aria-label="Abrir menu de ações do cliente">
                             <MoreHorizontal className="h-4 w-4" />
                           </Button>
                         </DropdownMenuTrigger>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -202,7 +202,7 @@ const Index = () => {
                         <CardTitle className="text-base font-semibold">
                           <button
                             type="button"
-                            className="text-left hover:underline focus:outline-none"
+                            className="text-left hover:underline focus:outline-none transition-transform active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded"
                             onClick={() => navigate(`/clients/${row.client_slug}`)}
                           >
                             {row.client_name}
@@ -218,7 +218,7 @@ const Index = () => {
                         </div>
                       </div>
                       <CollapsibleTrigger asChild>
-                        <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0 group">
+                        <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0 group focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2" aria-label="Expandir ou recolher padrões">
                           <ChevronDown className="h-4 w-4 group-data-[state=open]:hidden" />
                           <ChevronUp className="h-4 w-4 hidden group-data-[state=open]:block" />
                         </Button>


### PR DESCRIPTION
## Summary
- **active:scale:** SortButton (ClientsPage) `active:scale-[0.98]`; TableRow clickable `active:scale-[0.995]`; client name button (Index Dashboard card) `active:scale-[0.98]`. CollapsibleTrigger not changed (shadcn Button).
- **aria-label:** All icon-only buttons have aria-label (SortButton: "Ordenar por X"; ClientsPage row menu: "Abrir menu de ações do cliente"; Index CollapsibleTrigger: "Expandir ou recolher padrões"; ClientDetailPage Canais menu: "Menu do canal").
- **Keyboard:** TableRow is `role="button"`, `tabIndex={0}`, Enter/Space navigates to client; focus-visible ring inset on row.
- **focus-visible:** Explicit `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2` (or ring-inset for TableRow) on all interactive elements touched.

## CTO Checklist
- m11: Zero new imports; no unused imports.

## Test plan
- **ClientsPage:** Tab to sort buttons → focus-visible ring; click sort → active scale; Tab to row → Enter navigates; Tab to row menu icon → aria-label announced, Enter opens menu.
- **Index:** Click client name → active scale; Tab to expand button → aria-label, focus-visible ring.
- **ClientDetailPage (Canais):** Tab to channel menu icon → aria-label "Menu do canal", focus-visible ring.
- Visual: no layout or color changes; zero regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)