### PR TITLE
fix: busca server-side em ClientsPage, SearchPage e Dashboard

### DIFF
--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,10 @@
+import { useState, useEffect } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}

--- a/src/pages/ClientsPage.tsx
+++ b/src/pages/ClientsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState, useCallback, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { useAuth } from "@/context/AuthContext";
+import { useDebounce } from "@/hooks/useDebounce";
 import { usePriorityScores } from "@/hooks/usePriorityScores";
 
 // ── Types ──
@@ -135,6 +136,10 @@ const ClientsPage = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search.trim(), 300);
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearch]);
   const [page, setPage] = useState(0);
   const [includeInactive, setIncludeInactive] = useState(false);
   const [sortKey, setSortKey] = useState<SortCol>("last_contact");
@@ -157,9 +162,9 @@ const ClientsPage = () => {
   }, [sortKey]);
 
   const { data: clientsData, isLoading: loadingClients, isError: clientsError, refetch: refetchClients } = useQuery<{ list: ClientRow[]; totalCount: number }>({
-    queryKey: ["clients_list", user?.id, page, includeInactive],
+    queryKey: ["clients_list", user?.id, page, includeInactive, debouncedSearch],
     enabled: !!user?.id,
-    staleTime: 5 * 60 * 1000,
+    staleTime: debouncedSearch.length >= 3 ? 30_000 : 5 * 60 * 1000,
     queryFn: async () => {
       const from = page * PAGE_SIZE;
       const to = (page + 1) * PAGE_SIZE - 1;
@@ -168,6 +173,9 @@ const ClientsPage = () => {
         .select("id, name, slug, active, status, channel_bindings(channel, label, active)", { count: "exact" });
       if (!includeInactive) {
         query = query.in("status", ["ativo", "trial"]);
+      }
+      if (debouncedSearch.length >= 3) {
+        query = query.ilike("name", `%${debouncedSearch}%`);
       }
       const { data, error, count } = await query.order("name").range(from, to);
       if (error) throw error;
@@ -202,10 +210,7 @@ const ClientsPage = () => {
   const TONE_RANK: Record<string, number> = { ok: 0, atencao: 1, alerta: 2, critico: 3 };
 
   const clientsWithStats = useMemo(() => {
-    const q = search.toLowerCase().trim();
-    const list = clients
-      .map((c) => ({ ...c, stats: statsMap[c.id] ?? DEFAULT_STATS }))
-      .filter((c) => !q || c.name.toLowerCase().includes(q) || c.slug.toLowerCase().includes(q));
+    const list = clients.map((c) => ({ ...c, stats: statsMap[c.id] ?? DEFAULT_STATS }));
 
     list.sort((a, b) => {
       let cmp = 0;
@@ -239,7 +244,7 @@ const ClientsPage = () => {
     });
 
     return list;
-  }, [clients, statsMap, scoreMap, search, sortKey, sortDir]);
+  }, [clients, statsMap, scoreMap, sortKey, sortDir]);
 
   return (
     <div className="space-y-6">
@@ -293,7 +298,11 @@ const ClientsPage = () => {
           </div>
         ) : !clientsError && clientsWithStats.length === 0 ? (
           <div className="py-20 text-center text-muted-foreground text-sm">
-            Nenhum cliente encontrado. {includeInactive ? "Adicione um cliente para começar." : "Ative \"Incluir inativos\" para ver todos."}
+            {debouncedSearch.length >= 3
+              ? `Nenhum cliente encontrado para "${debouncedSearch}"`
+              : includeInactive
+                ? "Adicione um cliente para começar."
+                : "Nenhum cliente encontrado. Ative \"Incluir inativos\" para ver todos."}
           </div>
         ) : (
           <>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { useDebounce } from "@/hooks/useDebounce";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { formatDistanceToNow } from "date-fns";
@@ -92,6 +93,7 @@ const Index = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search.trim(), 300);
   const [tierFilter, setTierFilter] = useState<string>("all");
   const { isAdmin, isLoading: roleLoading } = useUserRole();
   const { data: scores, isLoading: scoresLoading, isError, refetch } = usePriorityScores();
@@ -145,15 +147,15 @@ const Index = () => {
   }, [list]);
   const filteredList = useMemo(() => {
     let result = list;
-    if (search.trim()) {
-      const q = search.toLowerCase().trim();
+    if (debouncedSearch.length >= 3) {
+      const q = debouncedSearch.toLowerCase();
       result = result.filter((r) => r.client_name.toLowerCase().includes(q));
     }
     if (tierFilter !== "all") {
       result = result.filter((r) => r.tier === tierFilter);
     }
     return result.slice(0, PAGE_SIZE);
-  }, [list, search, tierFilter]);
+  }, [list, debouncedSearch, tierFilter]);
 
   if (roleLoading) {
     return (
@@ -444,7 +446,7 @@ const Index = () => {
         </>
       )}
 
-      {!isError && !scoresLoading && list.length > PAGE_SIZE && !search.trim() && tierFilter === "all" && (
+      {!isError && !scoresLoading && list.length > PAGE_SIZE && debouncedSearch.length === 0 && tierFilter === "all" && (
         <p className="text-center text-sm text-muted-foreground">
           Exibindo os {PAGE_SIZE} primeiros de {list.length} clientes.
         </p>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
 import { formatDistanceToNow } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { Search as SearchIcon, AlertCircle } from "lucide-react";
@@ -23,12 +24,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useDebounce } from "@/hooks/useDebounce";
 import { useSearchInteractions } from "@/hooks/useSearchInteractions";
 import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
 import { useAuth } from "@/context/AuthContext";
 
 const PAGE_SIZE = 20;
-const DEBOUNCE_MS = 300;
 
 const TONE_CONFIG: Record<string, { label: string; className: string }> = {
   ok: { label: "✓ Ok", className: "bg-emerald-50 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400" },
@@ -45,22 +47,18 @@ interface ClientOption {
 const SearchPage = () => {
   const { user } = useAuth();
   const [inputValue, setInputValue] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const debouncedQuery = useDebounce(inputValue.trim(), 300);
   const [clientId, setClientId] = useState<string>("all");
   const [tone, setTone] = useState<string>("all");
   const [page, setPage] = useState(0);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      setDebouncedQuery(inputValue.trim());
-      setPage(0);
-    }, DEBOUNCE_MS);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [inputValue]);
+    setPage(0);
+  }, [debouncedQuery]);
+
+  useEffect(() => {
+    if (clientSearchError) toast.error("Erro ao buscar clientes");
+  }, [clientSearchError]);
 
   const { data: results = [], isLoading, isError, refetch } = useSearchInteractions({
     query: debouncedQuery,
@@ -82,6 +80,25 @@ const SearchPage = () => {
         .order("name");
       if (error) throw error;
       return (data ?? []) as ClientOption[];
+    },
+  });
+
+  const { data: clientMatches = [], isError: clientSearchError } = useQuery<
+    Array<{ id: string; name: string; slug: string; status: string }>
+  >({
+    queryKey: ["client-search", debouncedQuery],
+    enabled: debouncedQuery.length >= 3,
+    staleTime: 30_000,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("clients")
+        .select("id, name, slug, status")
+        .ilike("name", `%${debouncedQuery}%`)
+        .in("status", ["ativo", "trial"])
+        .order("name")
+        .limit(5);
+      if (error) throw error;
+      return (data ?? []) as Array<{ id: string; name: string; slug: string; status: string }>;
     },
   });
 
@@ -165,12 +182,45 @@ const SearchPage = () => {
         </div>
       )}
 
-      {!isError && showResults && !isLoading && results.length === 0 && (
+      {!isError && showResults && !isLoading && results.length === 0 && clientMatches.length === 0 && (
         <p className="text-sm text-muted-foreground">Nenhum resultado encontrado para &quot;{debouncedQuery}&quot;</p>
+      )}
+
+      {showResults && clientMatches.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-foreground">Clientes</h3>
+          <div className="grid gap-2">
+            {clientMatches.map((c) => (
+              <Link
+                key={c.id}
+                to={`/clients/${c.slug}`}
+                className="flex items-center justify-between rounded-lg border border-border bg-card px-4 py-3 transition-shadow duration-200 hover:shadow-md"
+              >
+                <div>
+                  <span className="font-medium text-sm text-foreground">{c.name}</span>
+                  <p className="text-xs text-muted-foreground">{c.slug}</p>
+                </div>
+                <span
+                  className={`inline-flex items-center rounded-sm px-2 py-0.5 text-xs font-medium ${
+                    c.status === "ativo"
+                      ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400"
+                      : c.status === "trial"
+                        ? "bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-400"
+                        : "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400"
+                  }`}
+                >
+                  {c.status === "ativo" ? "Ativo" : c.status === "trial" ? "Trial" : "Inativo"}
+                </span>
+              </Link>
+            ))}
+          </div>
+          <hr className="border-border" />
+        </div>
       )}
 
       {!isError && showResults && !isLoading && results.length > 0 && (
         <>
+          <h3 className="text-sm font-semibold text-foreground">Interações</h3>
           <p className="text-sm text-muted-foreground">
             {page * PAGE_SIZE + 1}-{Math.min((page + 1) * PAGE_SIZE, totalCount)} de {totalCount} resultados
           </p>


### PR DESCRIPTION
Implementa busca server-side e debounce conforme Issue #63.

## Alterações

### useDebounce (novo)
- `src/hooks/useDebounce.ts`: hook genérico `useDebounce<T>(value, delay)`, 300ms.

### ClientsPage
- Debounce no termo de busca (300ms); reset da paginação ao mudar `debouncedSearch`.
- Query Supabase: `.ilike("name", `%${debouncedSearch}%`)` quando `debouncedSearch.length >= 3`.
- `queryKey`: `["clients_list", user?.id, page, includeInactive, debouncedSearch]`.
- `staleTime`: 30s com filtro, 5min sem.
- Removido filtro client-side no `useMemo` (variável `q` e `.filter()`).
- Empty state: "Nenhum cliente encontrado para \"termo\"" quando busca ativa.

### SearchPage
- Debounce inline substituído por `useDebounce(inputValue.trim(), 300)`; `useEffect` só para reset de `page`.
- Nova query `client-search`: clientes por `.ilike("name", ...)`, status ativo/trial, limit 5; toast em erro.
- Seção **Clientes** acima da tabela (quando `showResults && clientMatches.length > 0`); título **Interações** na tabela.

### Dashboard (Index)
- `useDebounce(search.trim(), 300)`; filtro por nome no `useMemo` usa `debouncedSearch` e só aplica com `debouncedSearch.length >= 3` (client-side mantido, ~13 registros).

## Checklist CTO
- m4: staleTime 30s com filtro / 5min sem
- m5: queryKey com debouncedSearch
- m7: debounce 300ms
- m8: erros tratados (toast na busca de clientes)
- m11: useRef removido de SearchPage
- m12: reset page ao buscar (ClientsPage, SearchPage)

Closes #63

Made with [Cursor](https://cursor.com)